### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/crates/doctave-lib/src/assets/app.js
+++ b/crates/doctave-lib/src/assets/app.js
@@ -150,6 +150,15 @@ var mathElements = document.getElementsByClassName("math");
 
 const macros = {}
 
+// Utility: Escape special HTML characters to prevent XSS
+function escapeHtml(str) {
+    return str.replace(/&/g, "&amp;")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;")
+              .replace(/"/g, "&quot;")
+              .replace(/'/g, "&#39;");
+}
+
 for (let element of mathElements) {
     let latex = element.textContent;
 

--- a/crates/doctave-lib/src/assets/app.js
+++ b/crates/doctave-lib/src/assets/app.js
@@ -177,7 +177,7 @@ for (let element of mathElements) {
                 .replaceAll(/>/g, "&gt;")
                 .replaceAll("\n", "<br />");
 
-            element.innerHTML = "<p class='katex-error-msg'>" + error_message + "</p>" + latex.trim().replaceAll("\n", "<br />");
+            element.innerHTML = "<p class='katex-error-msg'>" + error_message + "</p>" + escapeHtml(latex.trim()).replaceAll("\n", "<br />");
             element.classList.add("katex-error");
         } else {
             throw e;  // other error


### PR DESCRIPTION
Potential fix for [https://github.com/yonasBSD/doctave/security/code-scanning/6](https://github.com/yonasBSD/doctave/security/code-scanning/6)

To fix this vulnerability, we need to ensure that the `latex` variable (which comes from `element.textContent`) is properly escaped before being injected into the HTML assignment via `element.innerHTML`. Escaping here means replacing `&`, `<`, and `>` characters (and optionally quotes) with their corresponding HTML entities to prevent unexpected HTML interpretation or script execution by the browser.

The fix is to implement (inside `crates/doctave-lib/src/assets/app.js`) an escaping function for HTML-unsafe characters, and use it to sanitize `latex` before embedding it with `element.innerHTML`.  
Specifically, in the `catch` branch for `katex.ParseError`, replace  
```js
element.innerHTML = "<p class='katex-error-msg'>" + error_message + "</p>" + latex.trim().replaceAll("\n", "<br />");
```
with something like  
```js
element.innerHTML = "<p class='katex-error-msg'>" + error_message + "</p>" + escapeHtml(latex.trim()).replaceAll("\n", "<br />");
```
and define an appropriate `escapeHtml` function above. No additional dependencies are required; this function can be implemented in pure JavaScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
